### PR TITLE
Add manual payment activation for new accounts

### DIFF
--- a/lib/services/subscription_service.dart
+++ b/lib/services/subscription_service.dart
@@ -23,7 +23,7 @@ enum SubscriptionState {
 
 /// Parsed subscription information kept in the user document.
 class SubscriptionStatus {
-  const SubscriptionStatus({
+  SubscriptionStatus({
     this.startDate,
     this.endDate,
     this.graceEndsAt,
@@ -60,9 +60,8 @@ class SubscriptionStatus {
   final Map<String, dynamic> raw;
 
   /// Quick factory for empty state (no subscription data).
-  factory SubscriptionStatus.empty() => SubscriptionStatus(
-        checkedAt: DateTime.now().toUtc(),
-      );
+  factory SubscriptionStatus.empty() =>
+      SubscriptionStatus(checkedAt: DateTime.now().toUtc());
 
   /// Builds the status from a Firestore document snapshot.
   factory SubscriptionStatus.fromSnapshot(
@@ -233,7 +232,12 @@ class SubscriptionService {
       updates['subscription.graceEndsAt'] = null;
     }
     updates['subscription.paymentMethod'] = paymentMethod;
-    updates['subscription.status'] = status;
+    if (status != null) {
+      updates['subscription.status'] = status;
+      updates['status'] = status;
+    } else {
+      updates['subscription.status'] = null;
+    }
     updates['subscription.updatedAt'] = FieldValue.serverTimestamp();
     updates['updatedAt'] = FieldValue.serverTimestamp();
     await _userDoc(uid).set(updates, SetOptions(merge: true));


### PR DESCRIPTION
## Summary
- add manual payment method capture and activation toggle to the registration form so new user documents record status and payment metadata
- expose a manual activation flow from the subscription required screen to store payment information and flip the subscription status
- update the subscription status model to avoid const constructor build issues and keep the top-level status field in sync

## Testing
- N/A (flutter command not available in environment)


------
https://chatgpt.com/codex/tasks/task_e_68d2e617436483209a38f1cba647c5d5