### PR TITLE
Ensure subscription status persists across navigation

### DIFF
--- a/lib/screens/auth_gate.dart
+++ b/lib/screens/auth_gate.dart
@@ -6,6 +6,10 @@ import '../widgets/subscription_scope.dart';
 import 'home_screen.dart';
 import 'login_screen.dart';
 import 'subscription_required_screen.dart';
+import 'biblioteca_legal_screen.dart';
+import 'video_screen.dart';
+import 'chat.dart';
+import 'user_profile_screen.dart';
 
 class AuthGate extends StatelessWidget {
   const AuthGate({super.key});
@@ -96,7 +100,7 @@ class _SubscriptionGateState extends State<_SubscriptionGate> {
           return SubscriptionScope(
             status: status,
             onRefresh: _refresh,
-            child: const HomeScreen(),
+            child: const _PrivateAreaNavigator(),
           );
         }
 
@@ -106,6 +110,63 @@ class _SubscriptionGateState extends State<_SubscriptionGate> {
           onSignOut: _signOut,
         );
       },
+    );
+  }
+}
+
+class _PrivateAreaNavigator extends StatefulWidget {
+  const _PrivateAreaNavigator();
+
+  @override
+  State<_PrivateAreaNavigator> createState() => _PrivateAreaNavigatorState();
+}
+
+class _PrivateAreaNavigatorState extends State<_PrivateAreaNavigator> {
+  final GlobalKey<NavigatorState> _navigatorKey = GlobalKey<NavigatorState>();
+
+  Future<bool> _handleWillPop() async {
+    final navigator = _navigatorKey.currentState;
+    if (navigator == null) return true;
+    final didPop = await navigator.maybePop();
+    return !didPop;
+  }
+
+  Route<dynamic> _onGenerateRoute(RouteSettings settings) {
+    Widget page;
+    switch (settings.name) {
+      case '/biblioteca':
+        page = const BibliotecaLegalScreen();
+        break;
+      case '/video':
+        page = const VideoScreen();
+        break;
+      case '/chat':
+        page = const ChatScreen();
+        break;
+      case '/perfil':
+        page = const UserProfileScreen();
+        break;
+      case '/home':
+      default:
+        page = const HomeScreen();
+        break;
+    }
+
+    return MaterialPageRoute<void>(
+      builder: (_) => page,
+      settings: settings,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return WillPopScope(
+      onWillPop: _handleWillPop,
+      child: Navigator(
+        key: _navigatorKey,
+        initialRoute: '/home',
+        onGenerateRoute: _onGenerateRoute,
+      ),
     );
   }
 }

--- a/lib/screens/user_profile_screen.dart
+++ b/lib/screens/user_profile_screen.dart
@@ -484,7 +484,8 @@ class _UserProfileScreenState extends State<UserProfileScreen> {
     try {
       await _auth.signOut();
       if (!mounted) return;
-      Navigator.of(context).pushNamedAndRemoveUntil('/', (route) => false);
+      Navigator.of(context, rootNavigator: true)
+          .pushNamedAndRemoveUntil('/', (route) => false);
     } catch (e) {
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/widgets/custom_drawer.dart
+++ b/lib/widgets/custom_drawer.dart
@@ -49,7 +49,8 @@ class CustomDrawer extends StatelessWidget {
         await FirebaseAuth.instance.signOut();
         // Volvemos a la raíz ('/') y AuthGate decide -> login
         // ignore: use_build_context_synchronously
-        Navigator.pushNamedAndRemoveUntil(context, '/', (r) => false);
+        Navigator.of(context, rootNavigator: true)
+            .pushNamedAndRemoveUntil('/', (r) => false);
       } catch (e) {
         // ignore: use_build_context_synchronously
         ScaffoldMessenger.of(context).showSnackBar(


### PR DESCRIPTION
## Summary
- wrap the authenticated area with a dedicated navigator that lives inside `SubscriptionScope`
- route authenticated pages through that navigator so the drawer always receives subscription status
- adjust sign-out flows to target the root navigator and keep the existing behaviour intact

## Testing
- `flutter analyze` *(fails: flutter command is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2eee073a883208e5d315a8df23357