### PR TITLE
Fix logout and back navigation with subscription scope

### DIFF
--- a/lib/screens/biblioteca_legal_screen.dart
+++ b/lib/screens/biblioteca_legal_screen.dart
@@ -307,15 +307,23 @@ class _BibliotecaLegalScreenState extends State<BibliotecaLegalScreen> {
   }
 
   // === UI ===
+  Future<void> _handleBack() async {
+    final navigator = Navigator.of(context);
+    final didPop = await navigator.maybePop();
+    if (!mounted || didPop || !navigator.mounted) return;
+    navigator.pushReplacementNamed('/home');
+  }
+
   Widget _topBackBar() {
-    return Container(
+    return Padding(
       padding: const EdgeInsets.fromLTRB(12, 12, 12, 8),
-      child: Row(
-        children: [
-          InkWell(
-            onTap: () => Navigator.of(context).maybePop(),
-            borderRadius: BorderRadius.circular(20),
-            child: Container(
+      child: InkWell(
+        onTap: _handleBack,
+        borderRadius: BorderRadius.circular(24),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Container(
               padding: const EdgeInsets.all(6),
               decoration: BoxDecoration(
                 color: Colors.white.withOpacity(.08),
@@ -324,18 +332,18 @@ class _BibliotecaLegalScreenState extends State<BibliotecaLegalScreen> {
               child: const Icon(Icons.arrow_back,
                   size: 18, color: _CapColors.text),
             ),
-          ),
-          const SizedBox(width: 8),
-          const Text(
-            'Regresar',
-            style: TextStyle(
-              color: _CapColors.text,
-              fontSize: 14,
-              fontWeight: FontWeight.w600,
-              letterSpacing: .2,
+            const SizedBox(width: 8),
+            const Text(
+              'Regresar',
+              style: TextStyle(
+                color: _CapColors.text,
+                fontSize: 14,
+                fontWeight: FontWeight.w600,
+                letterSpacing: .2,
+              ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }

--- a/lib/screens/chat.dart
+++ b/lib/screens/chat.dart
@@ -69,6 +69,13 @@ class _ChatScreenState extends State<ChatScreen> {
     Future.delayed(const Duration(milliseconds: 80), _animateToEnd);
   }
 
+  Future<void> _handleBack() async {
+    final navigator = Navigator.of(context);
+    final didPop = await navigator.maybePop();
+    if (!mounted || didPop || !navigator.mounted) return;
+    navigator.pushReplacementNamed('/home');
+  }
+
   @override
   void dispose() {
     _textCtrl.dispose();
@@ -106,12 +113,13 @@ class _ChatScreenState extends State<ChatScreen> {
             // Barra "Regresar" oscura
             Padding(
               padding: const EdgeInsets.fromLTRB(12, 12, 12, 6),
-              child: Row(
-                children: [
-                  InkWell(
-                    onTap: () => Navigator.of(context).maybePop(),
-                    borderRadius: BorderRadius.circular(20),
-                    child: Container(
+              child: InkWell(
+                onTap: _handleBack,
+                borderRadius: BorderRadius.circular(24),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Container(
                       padding: const EdgeInsets.all(6),
                       decoration: BoxDecoration(
                         color: Colors.white.withOpacity(.08),
@@ -120,17 +128,17 @@ class _ChatScreenState extends State<ChatScreen> {
                       child: const Icon(Icons.arrow_back,
                           size: 18, color: _CapColors.text),
                     ),
-                  ),
-                  const SizedBox(width: 8),
-                  const Text(
-                    'Regresar',
-                    style: TextStyle(
-                      color: _CapColors.text,
-                      fontSize: 14,
-                      fontWeight: FontWeight.w600,
+                    const SizedBox(width: 8),
+                    const Text(
+                      'Regresar',
+                      style: TextStyle(
+                        color: _CapColors.text,
+                        fontSize: 14,
+                        fontWeight: FontWeight.w600,
+                      ),
                     ),
-                  ),
-                ],
+                  ],
+                ),
               ),
             ),
 

--- a/lib/screens/user_profile_screen.dart
+++ b/lib/screens/user_profile_screen.dart
@@ -544,6 +544,13 @@ class _UserProfileScreenState extends State<UserProfileScreen> {
 
   // ------------------- UI -------------------
 
+  Future<void> _handleBack() async {
+    final navigator = Navigator.of(context);
+    final didPop = await navigator.maybePop();
+    if (!mounted || didPop || !navigator.mounted) return;
+    navigator.pushReplacementNamed('/home');
+  }
+
   void _showAvatarMenu(Offset position) async {
     final result = await showMenu<String>(
       context: context,
@@ -627,23 +634,28 @@ class _UserProfileScreenState extends State<UserProfileScreen> {
                       child: Row(
                         children: [
                           InkWell(
-                            onTap: () => Navigator.of(context).maybePop(),
-                            borderRadius: BorderRadius.circular(20),
-                            child: Container(
-                              padding: const EdgeInsets.all(6),
-                              decoration: BoxDecoration(
-                                color: Colors.white.withOpacity(.08),
-                                borderRadius: BorderRadius.circular(20),
-                              ),
-                              child: const Icon(Icons.arrow_back,
-                                  size: 18, color: _CapColors.text),
+                            onTap: _handleBack,
+                            borderRadius: BorderRadius.circular(24),
+                            child: Row(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                Container(
+                                  padding: const EdgeInsets.all(6),
+                                  decoration: BoxDecoration(
+                                    color: Colors.white.withOpacity(.08),
+                                    borderRadius: BorderRadius.circular(20),
+                                  ),
+                                  child: const Icon(Icons.arrow_back,
+                                      size: 18, color: _CapColors.text),
+                                ),
+                                const SizedBox(width: 8),
+                                const Text('Regresar',
+                                    style: TextStyle(
+                                        color: _CapColors.text,
+                                        fontWeight: FontWeight.w600)),
+                              ],
                             ),
                           ),
-                          const SizedBox(width: 8),
-                          const Text('Regresar',
-                              style: TextStyle(
-                                  color: _CapColors.text,
-                                  fontWeight: FontWeight.w600)),
                           const Spacer(),
                           OutlinedButton.icon(
                             style: OutlinedButton.styleFrom(

--- a/lib/screens/video_screen.dart
+++ b/lib/screens/video_screen.dart
@@ -198,19 +198,44 @@ class _VideoScreenState extends State<VideoScreen> {
   }
 
   // ---------- UI helpers ----------
+  Future<void> _handleBack() async {
+    final navigator = Navigator.of(context);
+    final didPop = await navigator.maybePop();
+    if (!mounted || didPop || !navigator.mounted) return;
+    navigator.pushReplacementNamed('/home');
+  }
+
   Widget _topBackBar() {
-    return Container(
+    return Padding(
       padding: const EdgeInsets.fromLTRB(12, 12, 12, 6),
-      child: Row(
-        children: const [
-          Icon(Icons.arrow_back, size: 18, color: _CapColors.text),
-          SizedBox(width: 6),
-          Text(
-            'Regresar',
-            style:
-                TextStyle(color: _CapColors.text, fontWeight: FontWeight.w600),
+      child: InkWell(
+        onTap: _handleBack,
+        borderRadius: BorderRadius.circular(24),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 2, vertical: 2),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Container(
+                padding: const EdgeInsets.all(6),
+                decoration: BoxDecoration(
+                  color: Colors.white.withOpacity(.08),
+                  borderRadius: BorderRadius.circular(20),
+                ),
+                child: const Icon(Icons.arrow_back,
+                    size: 18, color: _CapColors.text),
+              ),
+              const SizedBox(width: 8),
+              const Text(
+                'Regresar',
+                style: TextStyle(
+                  color: _CapColors.text,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ],
           ),
-        ],
+        ),
       ),
     );
   }

--- a/lib/widgets/custom_drawer.dart
+++ b/lib/widgets/custom_drawer.dart
@@ -43,19 +43,22 @@ class CustomDrawer extends StatelessWidget {
     }
 
     Future<void> _signOut() async {
-      // Cierra el drawer
-      Navigator.pop(context);
+      final rootNavigator = Navigator.of(context, rootNavigator: true);
+      final messenger = ScaffoldMessenger.of(context);
+
+      // Cierra el drawer sin alterar el stack de pantallas
+      Scaffold.maybeOf(context)?.closeDrawer();
+
       try {
         await FirebaseAuth.instance.signOut();
-        // Volvemos a la raíz ('/') y AuthGate decide -> login
-        // ignore: use_build_context_synchronously
-        Navigator.of(context, rootNavigator: true)
-            .pushNamedAndRemoveUntil('/', (r) => false);
+        if (!rootNavigator.mounted) return;
+        rootNavigator.pushNamedAndRemoveUntil('/', (r) => false);
       } catch (e) {
-        // ignore: use_build_context_synchronously
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('No se pudo cerrar sesión: $e')),
-        );
+        if (messenger.mounted) {
+          messenger.showSnackBar(
+            SnackBar(content: Text('No se pudo cerrar sesión: $e')),
+          );
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- close the drawer safely before signing out and use the root navigator to reset the stack after Firebase sign-out
- add a shared back handler that falls back to Home when there is nothing to pop and wire it to the "Regresar" affordance on video, biblioteca, chat and profile screens

## Testing
- Not run (flutter not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d40bd09980832085d724596224a0b2